### PR TITLE
fix (removing CHAIN) removes CHAIN env variable and associated functions

### DIFF
--- a/src/chain-operations/getContractInstances.js
+++ b/src/chain-operations/getContractInstances.js
@@ -5,14 +5,14 @@ import getTXLibContracts from "../utils/getLibrariesContracts.js";
 
 config();
 
-async function getContractInstance(chain, address) {
+async function getContractInstance(address) {
     const WALLET_PRIVATE_KEY = process.env.PRIVATE_KEY;
     const RPC_URL = process.env.RPC_URL;
     const CHAIN_ID = parseInt(process.env.CHAIN_ID); // Convert to integer
 
     const customNetwork = {
         chainId: CHAIN_ID, // Use the CHAIN_ID from .env
-        name: chain, // Use the chain parameter as the network name
+        name: "network",
     };
 
     const provider = new ethers.JsonRpcProvider(RPC_URL, customNetwork);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -17,7 +17,7 @@ router.post("/mint-cap-table", async (req, res) => {
         const issuer = await seedDB(manifest);
 
         const issuerIdBytes16 = convertUUIDToBytes16(issuer._id);
-        const { contract, address, provider, libraries } = await deployCapTable(req.chain, issuerIdBytes16, issuer.legal_name, issuer.initial_shares_authorized);
+        const { contract, address, provider, libraries } = await deployCapTable(issuerIdBytes16, issuer.legal_name, issuer.initial_shares_authorized);
 
         const savedIssuerWithDeployedTo = await updateIssuerById(issuer._id, { deployed_to: address });
 

--- a/src/routes/issuer.js
+++ b/src/routes/issuer.js
@@ -42,8 +42,6 @@ issuer.get("/total-number", async (req, res) => {
 });
 
 issuer.post("/create", async (req, res) => {
-    const { chain } = req;
-
     try {
         // OCF doesn't allow extra fields in their validation
         const incomingIssuerToValidate = {
@@ -59,7 +57,6 @@ issuer.post("/create", async (req, res) => {
         const issuerIdBytes16 = convertUUIDToBytes16(incomingIssuerToValidate.id);
         console.log("💾 | Issuer id in bytes16 ", issuerIdBytes16);
         const { contract, provider, address, libraries } = await deployCapTable(
-            chain,
             issuerIdBytes16,
             incomingIssuerToValidate.legal_name,
             incomingIssuerToValidate.initial_shares_authorized


### PR DESCRIPTION
## What?

- removes CHAIN env variable and associated functionality.
- trying a general custom network name so it works for both local anvil and L2s

## Why?

- chain distinction is no longer needed since the server will run for one chain. Multi-chain support needs to be built if wanted

## Screenshots (optional)

