### PR TITLE
feat (separating docker files)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,4 +12,4 @@ RUN yarn install
 
 EXPOSE 8080
 # Specify the command to run on container start
-CMD ["node", "src/server.js"]
+CMD ["npx tsx", "src/server.js"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,15 @@
+# Use the official node image as a parent image
+FROM node:18
+
+# Set the working directory
+WORKDIR /app
+
+# COPY ./chain/out ./chain/out
+COPY . .
+
+# Install dependencies and setup
+RUN yarn install
+
+EXPOSE 8080
+# Specify the command to run on container start
+CMD ["npx tsx", "src/server.js --finalized-only"]


### PR DESCRIPTION
## What?

- Separates Dockerfiles into Dockerfile.dev and Dockerfile.prod

## Why?

- Prod needs to run with the --finalized-only flag which waits until block has been finalized to process events.
- As we continue building, it's likely that we continue to see separation of environments a need

## Screenshots (optional)

