### PR TITLE
Add getters for stakeholder by wallet and issuer_assigned_id

### DIFF
--- a/src/controllers/stakeholderController.js
+++ b/src/controllers/stakeholderController.js
@@ -49,6 +49,13 @@ export const getStakeholderById = async (contract, id) => {
     return { stakeholderId, type, role };
 };
 
+export const getStakeholderByWalletAddress = async (contract, walletAddress) => {
+    // Second: get stakeholder onchain
+    const stakeholderId = await contract.getStakeholderIdByWallet(walletAddress);
+    console.log("Stakeholder:", { stakeholderId });
+    return { stakeholderId };
+};
+
 export const getTotalNumberOfStakeholders = async (contract) => {
     const totalStakeholders = await contract.getTotalNumberOfStakeholders();
     console.log("＃ | Total number of stakeholders:", totalStakeholders.toString());

--- a/src/db/operations/read.js
+++ b/src/db/operations/read.js
@@ -20,6 +20,10 @@ export const readStakeholderById = async (id) => {
     return await findById(Stakeholder, id);
 };
 
+export const readStakeholderByIssuerAssignedId = async (id) => {
+    return await find(Stakeholder, { issuerAssignedId: id }).populate("transaction");
+};
+
 export const readStockClassById = async (id) => {
     return await findById(StockClass, id);
 };
@@ -90,8 +94,8 @@ export const getAllIssuerDataById = async (issuerId) => {
 
 export const readAllIssuers = async () => {
     return await find(Issuer);
-}
+};
 
 export const readfactories = async () => {
     return await find(Factory);
-}
+};


### PR DESCRIPTION
## What?

* Adding more getters for stakeholders based on fields other than the mongo UUID. 

* Also conditionally check for the `WalletAlreadyExists(address)` selector (`0x789a109e`) in the /add-wallet endpoint so it can more gracefully handle the contract error and return a successful response.

## Why?

One use case that we want to support is being able to find or create a stakeholder starting from a User external to the TAP system.

## Screenshots (optional)

