### PR TITLE
Set customId on stock transfer

### DIFF
--- a/chain/src/CapTable.sol
+++ b/chain/src/CapTable.sol
@@ -294,33 +294,32 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRulesUpgradeable {
     }
 
     /// @inheritdoc ICapTable
-    function transferStock(
-        bytes16 transferorStakeholderId,
-        bytes16 transfereeStakeholderId,
-        bytes16 stockClassId,
-        bool isBuyerVerified,
-        uint256 quantity,
-        uint256 sharePrice,
-        string calldata customId
-    ) external override onlyOperator {
-        _checkStakeholderIsStored(transferorStakeholderId);
-        _checkStakeholderIsStored(transfereeStakeholderId);
-        _checkInvalidStockClass(stockClassId);
+    function transferStock(StockTransferParams calldata params) external override onlyOperator {
+        _checkStakeholderIsStored(params.transferor_stakeholder_id);
+        _checkStakeholderIsStored(params.transferee_stakeholder_id);
+        _checkInvalidStockClass(params.stock_class_id);
 
         nonce++;
 
-        StockTransferParams memory params = StockTransferParams(
-            transferorStakeholderId,
-            transfereeStakeholderId,
-            stockClassId,
-            isBuyerVerified,
-            quantity,
-            sharePrice,
+        StockTransferParams memory transferParams = StockTransferParams(
+            params.transferor_stakeholder_id,
+            params.transferee_stakeholder_id,
+            params.stock_class_id,
+            params.is_buyer_verified,
+            params.quantity,
+            params.share_price,
             nonce,
-            customId
+            params.custom_id
         );
 
-        StockLib.createTransfer(params, positions, activeSecs, transactions, issuer, stockClasses[stockClassIndex[stockClassId] - 1]);
+        StockLib.createTransfer(
+            transferParams,
+            positions,
+            activeSecs,
+            transactions,
+            issuer,
+            stockClasses[stockClassIndex[params.stock_class_id] - 1]
+        );
     }
 
     /// @inheritdoc ICapTable

--- a/chain/src/CapTable.sol
+++ b/chain/src/CapTable.sol
@@ -300,7 +300,8 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRulesUpgradeable {
         bytes16 stockClassId,
         bool isBuyerVerified,
         uint256 quantity,
-        uint256 share_price
+        uint256 sharePrice,
+        string memory customId
     ) external override onlyOperator {
         _checkStakeholderIsStored(transferorStakeholderId);
         _checkStakeholderIsStored(transfereeStakeholderId);
@@ -314,8 +315,9 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRulesUpgradeable {
             stockClassId,
             isBuyerVerified,
             quantity,
-            share_price,
-            nonce
+            sharePrice,
+            nonce,
+            customId
         );
 
         StockLib.createTransfer(params, positions, activeSecs, transactions, issuer, stockClasses[stockClassIndex[stockClassId] - 1]);

--- a/chain/src/CapTable.sol
+++ b/chain/src/CapTable.sol
@@ -301,7 +301,7 @@ contract CapTable is ICapTable, AccessControlDefaultAdminRulesUpgradeable {
         bool isBuyerVerified,
         uint256 quantity,
         uint256 sharePrice,
-        string memory customId
+        string calldata customId
     ) external override onlyOperator {
         _checkStakeholderIsStored(transferorStakeholderId);
         _checkStakeholderIsStored(transfereeStakeholderId);

--- a/chain/src/interfaces/ICapTable.sol
+++ b/chain/src/interfaces/ICapTable.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import { AccessControlDefaultAdminRules } from "openzeppelin/contracts/access/AccessControlDefaultAdminRules.sol";
-import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, InitialShares, ShareNumbersIssued, StockParams, StockParamsQuantity, StockIssuanceParams } from "../lib/Structs.sol";
+import { Issuer, Stakeholder, StockClass, ActivePositions, SecIdsStockClass, StockLegendTemplate, InitialShares, ShareNumbersIssued, StockParams, StockParamsQuantity, StockIssuanceParams, StockTransferParams } from "../lib/Structs.sol";
 
 interface ICapTable {
     // @dev Transactions will be created on-chain then reflected off-chain.
@@ -92,15 +92,7 @@ interface ICapTable {
 
     function cancelStock(StockParams calldata params, uint256 quantity) external;
 
-    function transferStock(
-        bytes16 transferorStakeholderId,
-        bytes16 transfereeStakeholderId,
-        bytes16 stockClassId,
-        bool isBuyerVerified,
-        uint256 quantity,
-        uint256 sharePrice,
-        string calldata custom_id
-    ) external;
+    function transferStock(StockTransferParams calldata params) external;
 
     function addAdmin(address addr) external;
 

--- a/chain/src/interfaces/ICapTable.sol
+++ b/chain/src/interfaces/ICapTable.sol
@@ -98,7 +98,8 @@ interface ICapTable {
         bytes16 stockClassId,
         bool isBuyerVerified,
         uint256 quantity,
-        uint256 share_price
+        uint256 sharePrice,
+        string memory custom_id
     ) external;
 
     function addAdmin(address addr) external;

--- a/chain/src/interfaces/ICapTable.sol
+++ b/chain/src/interfaces/ICapTable.sol
@@ -99,7 +99,7 @@ interface ICapTable {
         bool isBuyerVerified,
         uint256 quantity,
         uint256 sharePrice,
-        string memory custom_id
+        string calldata custom_id
     ) external;
 
     function addAdmin(address addr) external;

--- a/chain/src/lib/Stock.sol
+++ b/chain/src/lib/Stock.sol
@@ -106,7 +106,8 @@ library StockLib {
                 true,
                 remainingQuantity,
                 activePosition.share_price,
-                params.nonce
+                params.nonce,
+                ""
             );
             StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
                 transferParams,
@@ -190,7 +191,8 @@ library StockLib {
                 true,
                 remainingQuantity,
                 activePosition.share_price,
-                params.nonce
+                params.nonce,
+                ""
             );
             StockIssuance memory balanceIssuance = TxHelper.createStockIssuanceStructForTransfer(
                 transferParams,

--- a/chain/src/lib/Stock.sol
+++ b/chain/src/lib/Stock.sol
@@ -301,7 +301,8 @@ library StockLib {
             params.is_buyer_verified,
             params.quantity,
             params.share_price,
-            params.nonce
+            params.nonce,
+            params.custom_id
         );
         newParams.quantity = balanceForTransferor;
         newParams.share_price = transferorActivePosition.share_price;

--- a/chain/src/lib/Structs.sol
+++ b/chain/src/lib/Structs.sol
@@ -156,6 +156,7 @@ struct StockTransferParams {
     uint256 quantity;
     uint256 share_price;
     uint256 nonce;
+    string custom_id;
 }
 
 struct StockIssuanceParams {

--- a/chain/src/lib/TxHelper.sol
+++ b/chain/src/lib/TxHelper.sol
@@ -63,7 +63,7 @@ library TxHelper {
             new bytes16[](0), // Stock legend IDs (optional)
             "", // Issuance type (optional)
             new string[](0), // Comments
-            "", // Custom ID (optional)
+            transferParams.custom_id, // Custom ID (optional)
             stakeholderId, // Stakeholder ID
             "", // Board approval date (optional)
             "", // Stockholder approval date (optional)

--- a/chain/test/AccessControl.t.sol
+++ b/chain/test/AccessControl.t.sol
@@ -38,13 +38,18 @@ contract RolesTests is CapTableTest {
 
         // will revert because we haven't performed an issuance, but it would have already verified operator
         // role working
-        capTable.transferStock(
+        StockTransferParams memory params = StockTransferParams(
             stakeholderIds[0], // transferor
             stakeholderIds[1], // transferee
             stockClassId,
             true,
             100,
-            100
+            100,
+            0,
+            ""
+        );
+        capTable.transferStock(
+            params
         );
     }
 

--- a/chain/test/StockTransfer.t.sol
+++ b/chain/test/StockTransfer.t.sol
@@ -36,7 +36,17 @@ contract StockTransferTest is CapTableTest {
         // Transfer stock
         uint256 quantityToTransfer = 3500;
         uint256 price = 25;
-        capTable.transferStock(transferorStakeholderId, transfereeStakeholderId, stockClassId, true, quantityToTransfer, price);
+        StockTransferParams memory params = StockTransferParams(
+            transferorStakeholderId,
+            transfereeStakeholderId,
+            stockClassId,
+            true,
+            quantityToTransfer,
+            price,
+            0,
+            ""
+        );
+        capTable.transferStock(params);
 
         uint256 transactionsCount = capTable.getTransactionsCount();
         bytes memory lastIssuanceTx = capTable.transactions(transactionsCount - 2);
@@ -66,6 +76,16 @@ contract StockTransferTest is CapTableTest {
 
         bytes memory expectedError = abi.encodeWithSignature("InsufficientShares(uint256,uint256)", totalIssued, quantityToTransfer);
         vm.expectRevert(expectedError);
-        capTable.transferStock(transferorStakeholderId, transfereeStakeholderId, stockClassId, true, quantityToTransfer, price);
+        StockTransferParams memory params = StockTransferParams(
+            transferorStakeholderId,
+            transfereeStakeholderId,
+            stockClassId,
+            true,
+            quantityToTransfer,
+            price,
+            0,
+            ""
+        );
+        capTable.transferStock(params);
     }
 }

--- a/src/controllers/transactions/transferController.js
+++ b/src/controllers/transactions/transferController.js
@@ -13,12 +13,7 @@ export const convertAndCreateTransferStockOnchain = async (contract, transfer) =
     const sharePriceScaled = toScaledBigNumber(sharePrice);
 
     const tx = await contract.transferStock(
-        transferorIdBytes16,
-        transfereeIdBytes16,
-        stockClassIdBytes16,
-        isBuyerVerified,
-        quantityScaled,
-        sharePriceScaled
+        (transferorIdBytes16, transfereeIdBytes16, stockClassIdBytes16, isBuyerVerified, quantityScaled, sharePriceScaled, "")
     );
     await tx.wait();
     console.log(`Initiate Stock Transfer from transferee ID: ${transfereeId} to transferor ID: ${transferorId}`);


### PR DESCRIPTION
## What?

Pass through custom_id from the `transferStock` method to the stock issuance that happens internally.
* Update `transferStock` params to a struct to fix --via-ir issues that popped up from adding another argument
* Continue to default to empty string if no customId is passed in

## Why?

 This allows us to link an external order id to the issuance and transfer for easier cross referencing between TAP entries and external systems.

## Screenshots (optional)

