### PR TITLE
Af/fix decimal scaling

### DIFF
--- a/src/chain-operations/transactionHandlers.js
+++ b/src/chain-operations/transactionHandlers.js
@@ -26,6 +26,7 @@ const options = {
     second: "2-digit",
 };
 export const handleStockIssuance = async (stock, issuerId, timestamp) => {
+    const currency = "USD";
     const { id, object_type, security_id, params } = stock;
     console.log("StockIssuanceCreated Event Emitted!", id);
     const {
@@ -47,13 +48,13 @@ export const handleStockIssuance = async (stock, issuerId, timestamp) => {
         security_law_exemptions,
     } = params;
     const sharePriceOCF = {
-        amount: toDecimal(share_price).toString(),
-        currency: "USD",
+        amount: toDecimal(share_price, currency).toString(),
+        currency,
     };
 
     // Type represention of an ISO-8601 date, e.g. 2022-01-28.
     const dateOCF = new Date(timestamp * 1000).toISOString().split("T")[0];
-    const costBasisOCF = { amount: toDecimal(cost_basis).toString(), currency: "USD" };
+    const costBasisOCF = { amount: toDecimal(cost_basis, currency).toString(), currency };
     const share_numbers_issuedOCF = [
         {
             starting_share_number: toDecimal(starting_share_number).toString(),

--- a/src/controllers/stakeholderController.js
+++ b/src/controllers/stakeholderController.js
@@ -11,10 +11,7 @@ export const convertAndReflectStakeholderOnchain = async (contract, stakeholder)
     console.log("Stakeholder id for seeding ", stakeholderIdBytes16);
 
     // Second: create stakeholder onchain
-    const tx = await contract.createStakeholder(stakeholderIdBytes16, stakeholder.stakeholder_type, stakeholder.current_relationship, {
-        gasPrice: ethers.parseUnits("500", "gwei"),
-        gasLimit: 1000000,
-    });
+    const tx = await contract.createStakeholder(stakeholderIdBytes16, stakeholder.stakeholder_type, stakeholder.current_relationship);
     await tx.wait();
 
     console.log("✅ | Stakeholder created  onchain");

--- a/src/utils/convertToFixedPointDecimals.js
+++ b/src/utils/convertToFixedPointDecimals.js
@@ -1,18 +1,26 @@
 import { toBigInt } from "ethers";
 
 export const decimalScaleValue = 1e10;
+export const usdcDecimalScaleValue = 1e6;
+
+function getScale(currency) {
+    if (currency === "USD") {
+        return usdcDecimalScaleValue;
+    }
+    return decimalScaleValue;
+}
 
 // Convert a price to a BigInt
-function toScaledBigNumber(price) {
-    return toBigInt(Math.round(price * decimalScaleValue).toString());
+function toScaledBigNumber(price, currency) {
+    return toBigInt(Math.round(price * getScale(currency)).toString());
 }
 
 // TODO: might not be refactored correctly from ethers v5 to v6
 // Convert a BigInt back to a decimal price
-function toDecimal(scaledPriceBigInt) {
+function toDecimal(scaledPriceBigInt, currency) {
     if (typeof scaledPriceBigInt === "bigint") {
         const numberString = scaledPriceBigInt.toString();
-        return parseFloat(numberString / decimalScaleValue).toString();
+        return parseFloat(numberString / getScale(currency)).toString();
     } else {
         return scaledPriceBigInt;
     }


### PR DESCRIPTION
## What?

Modify `toDecimal` to optionally take in a currency. If the currency is USD then we scale by the USDC decimals instead of the internal TAP decimals.

## Why?

When processing transactions, the current logic will interpret share prices stored in on-chain transactions as being in TAP internal decimals of 1e10. This means that if the share price for a trade is $1.30 the value will show up as .00013 in mongo instead of 1.3

## Screenshots (optional)

