### PR TITLE
fix(server): use @tap/units and repair issuer lookup

### DIFF
--- a/docs/src/content/api-reference.mdx
+++ b/docs/src/content/api-reference.mdx
@@ -33,6 +33,7 @@ Each router mounts a `GET` that returns text so you can confirm it's up: `GET /`
 | --- | --- | --- | --- | --- |
 | `POST` | `/mint-cap-table` | Onchain + DB | OCF manifest zip as `multipart/form-data` field `file`. | `{ issuer }` |
 | `POST` | `/factory/register` | DB-only | `factory_address`, `implementation_address` | `{ factory }` |
+| `GET` | `/issuer/id/:id` | DB-only | Path `id`. | Full issuer document (same as `/issuer/full/:id`). |
 | `GET` | `/issuer/total-number` | DB-only | None. | Count. |
 | `POST` | `/issuer/create` | Onchain + DB | OCF issuer fields. | `{ issuer }` |
 | `POST` | `/issuer/register` | DB-only | OCF issuer fields plus `deployed_to`, `tx_hash`, optional bytes16 `id`. | `{ issuer }` |

--- a/docs/src/content/features/issuer-management/create-issuer.mdx
+++ b/docs/src/content/features/issuer-management/create-issuer.mdx
@@ -73,7 +73,7 @@ After the import finishes, use the returned issuer record for later API calls, t
 
 ## Read issuer records
 
-- `GET /issuer/full/:id` returns the full issuer document.
+- `GET /issuer/id/:id` and `GET /issuer/full/:id` return the full issuer document.
 - `GET /issuer/total-number` returns the issuer count.
 
 For most workflows, the response from `POST /issuer/create` or `POST /issuer/register` is still the main issuer record you keep.
@@ -81,7 +81,7 @@ For most workflows, the response from `POST /issuer/create` or `POST /issuer/reg
 ## Verify
 
 1. Confirm the response contains `_id`, `deployed_to`, and `tx_hash`.
-2. `GET /issuer/full/:id` with the returned `_id` should succeed.
+2. `GET /issuer/id/:id` (or `/issuer/full/:id`) with the returned `_id` should succeed.
 3. After ~20 seconds, `GET /historical-transactions/issuer-id/<YOUR_ISSUER_ID>` should include any seeded transactions (manifest imports only).
 
 ## What's next?

--- a/server/controllers/transactions/issuanceController.js
+++ b/server/controllers/transactions/issuanceController.js
@@ -66,7 +66,7 @@ export const convertAndCreateIssuanceStockOnchain = async (contract, issuance) =
         quantity: toScaledBigNumber(quantity),
         vesting_terms_id: convertUUIDToBytes16(vesting_terms_id),
         cost_basis, // not converted
-        stock_legend_ids,
+        stock_legend_ids: StockLegendIdsBytes16,
         issuance_type,
         comments,
         custom_id,

--- a/server/routes/capTable.ts
+++ b/server/routes/capTable.ts
@@ -3,8 +3,8 @@ import Issuer from "../db/objects/Issuer";
 import Stakeholder from "../db/objects/Stakeholder";
 import StockClass from "../db/objects/StockClass";
 import { StockIssuance } from "../db/objects/transactions/issuance";
+import { unscale } from "@tap/units";
 import { getIssuerContract } from "../utils/caches";
-import { decimalScaleValue } from "../utils/convertToFixedPointDecimals";
 import { convertUUIDToBytes16 } from "../utils/convertUUID";
 
 export const capTable = Router();
@@ -64,18 +64,15 @@ capTable.get("/holdings/stock", async (req, res) => {
 						convertUUIDToBytes16(stakeholder._id),
 						convertUUIDToBytes16(stockClass._id),
 					);
-					if (quantity == 0n || quantity === 0 || quantity === "0") {
-						continue;
-					}
-					const q = Number(quantity);
-					const qp = Number(quantityPrice);
-					if (!Number.isFinite(q) || q === 0) continue;
-					const sharePrice = q !== 0 ? qp / q : 0;
+					const q = typeof quantity === "bigint" ? quantity : BigInt(quantity);
+					if (q === 0n) continue;
+					const qp = typeof quantityPrice === "bigint" ? quantityPrice : BigInt(quantityPrice);
+					const sharePriceScaled = qp / q;
 					holdings.push({
 						stockClass,
 						stakeholder,
-						quantity: q / decimalScaleValue,
-						sharePrice: sharePrice / decimalScaleValue,
+						quantity: Number(unscale(q)),
+						sharePrice: Number(unscale(sharePriceScaled)),
 						timestamp: Number(timestamp),
 					});
 				} catch (pairErr) {

--- a/server/routes/issuer.js
+++ b/server/routes/issuer.js
@@ -19,14 +19,15 @@ issuer.get("/", async (req, res) => {
     res.send(`Hello issuer!`);
 });
 
-//WIP get routes are currently fetching offchain.
 issuer.get("/id/:id", async (req, res) => {
     const { id } = req.params;
 
     try {
-        const { issuerId, type, role } = await readIssuerById(id);
-
-        res.status(200).send({ issuerId, type, role });
+        const issuerDoc = await readIssuerById(id);
+        if (!issuerDoc) {
+            return res.status(404).send("Issuer not found");
+        }
+        res.status(200).send(issuerDoc);
     } catch (error) {
         console.error(error);
         res.status(500).send(`${error}`);

--- a/server/utils/convertToFixedPointDecimals.js
+++ b/server/utils/convertToFixedPointDecimals.js
@@ -1,35 +1,26 @@
 import { toBigInt } from "ethers";
+import { SCALE, scaleAmount, unscale } from "@tap/units";
 
-export const decimalScaleValue = 1e10;
-export const usdcDecimalScaleValue = 1e6;
+/** Protocol scale is always 1e10. Do not use a USD/USDC 1e6 fork. */
+export const decimalScaleValue = Number(SCALE);
 
-function getScale(currency) {
-    if (currency === "USD") {
-        return usdcDecimalScaleValue;
-    }
-    return decimalScaleValue;
+function toScaledBigNumber(value) {
+    return scaleAmount(value);
 }
 
-// Convert a price to a BigInt
-function toScaledBigNumber(price, currency) {
-    return toBigInt(Math.round(price * getScale(currency)).toString());
-}
-
-// TODO: might not be refactored correctly from ethers v5 to v6
-// Convert a BigInt back to a decimal price
-function toDecimal(scaledPriceBigInt, currency) {
+function toDecimal(scaledPriceBigInt) {
     if (typeof scaledPriceBigInt === "bigint") {
-        const numberString = scaledPriceBigInt.toString();
-        return parseFloat(numberString / getScale(currency)).toString();
-    } else {
-        return scaledPriceBigInt;
+        return unscale(scaledPriceBigInt);
     }
+    if (typeof scaledPriceBigInt === "number" || typeof scaledPriceBigInt === "string") {
+        try {
+            return unscale(scaledPriceBigInt);
+        } catch {
+            return scaledPriceBigInt;
+        }
+    }
+    return scaledPriceBigInt;
 }
-
-// const convertTimeStampToUint40 = (date) => {
-//     const datetime = new Date(date);
-//     return toBigInt(Math.floor(datetime.getTime() / 1000)).toNumber();
-// };
 
 const convertTimeStampToUint40 = (date) => {
     const datetime = new Date(date);

--- a/server/utils/convertUUID.js
+++ b/server/utils/convertUUID.js
@@ -1,45 +1,30 @@
-import { hexlify, getBytes } from "ethers";
+import { bytes16ToUuid, uuidToBytes16 } from "@tap/units";
 
 function convertToUUID(uuidBytes16) {
-    let uuidWithoutDashes = uuidBytes16.substring(2); // removes the '0x' prefix
-    let uuid = [
-        uuidWithoutDashes.slice(0, 8),
-        "-",
-        uuidWithoutDashes.slice(8, 12),
-        "-",
-        uuidWithoutDashes.slice(12, 16),
-        "-",
-        uuidWithoutDashes.slice(16, 20),
-        "-",
-        uuidWithoutDashes.slice(20),
-    ].join("");
-    return uuid;
+    return bytes16ToUuid(uuidBytes16);
 }
 
 function convertBytes16ToUUID(obj) {
-    // single value
-    if (typeof obj === "string" && obj.startsWith("0x")) {
-        return convertToUUID(obj);
-        // handing events
+    if (typeof obj === "string" && (obj.startsWith("0x") || obj.startsWith("0X"))) {
+        const hex = obj.slice(2);
+        if (hex.length === 32 && /^[0-9a-fA-F]+$/.test(hex)) {
+            return convertToUUID(obj);
+        }
+        return obj;
     } else if (Array.isArray(obj)) {
         return obj.map((item) => convertBytes16ToUUID(item));
     } else if (typeof obj === "object" && obj !== null) {
-        let newObject = {};
-        for (let key in obj) {
+        const newObject = {};
+        for (const key in obj) {
             newObject[key] = convertBytes16ToUUID(obj[key]);
         }
         return newObject;
-    } else {
-        return obj;
     }
+    return obj;
 }
 
 function convertUUIDToBytes16(uuid) {
-    const bytes = getBytes("0x" + uuid.replace(/-/g, ""));
-
-    const hex = hexlify(bytes);
-
-    return hex;
+    return uuidToBytes16(uuid);
 }
 
 export { convertBytes16ToUUID, convertUUIDToBytes16 };


### PR DESCRIPTION
## What?

Follow-up to #281.

- Server scale/UUID helpers now wrap `@tap/units`. Poller unscale is always **1e10** (the USD 1e6 branch is gone).
- Holdings uses `unscale` instead of `Number / 1e10`.
- `GET /issuer/id/:id` returns the full issuer document (or 404), same as `/issuer/full/:id`.
- Operator `issueStock` now sends converted `stock_legend_ids` (bytes16) instead of dropping them.

## Why?

Writes already scale at 1e10. The poller hardcoded `currency = "USD"` and unscaled at 1e6, which would store inflated prices. `GET /issuer/id/:id` destructured fields that do not exist on Issuer. Legend IDs were converted then ignored.

## How?

Compatibility wrappers keep existing `convertUUIDToBytes16` / `toScaledBigNumber` / `toDecimal` call sites. Recursive UUID conversion still skips 20-byte addresses. Docs restore `/issuer/id/:id` as a working full-document lookup.

**Verify:** `pnpm typecheck:server`, `pnpm test:units`, eslint on touched files.