### PR TITLE
refactor(app): split CapTableDashboard into nav-named screens

### DIFF
--- a/app/WARP.md
+++ b/app/WARP.md
@@ -54,7 +54,7 @@ pnpm generate:wagmi   # Regenerate src/generated.ts from chain ABIs
   - Design system: `theme.ts`, `global-style.ts`, `typography.tsx`, `elements.tsx`, `forms.tsx`, `layout.tsx` (+ `PageHeader.tsx`)
   - `shell/` — `AppShell` (shell root), `TopBar` (system bar), `SideNav` (working nav), `AppShellContext`, `navConfig`, `WalletButtonClient` (re-export)
   - `wallet/` — native connect modal + account menu (`WalletButton`, `WalletModal`, `AccountMenu`, connector ordering helpers)
-  - `cap-table/` — `CapTableDashboard.tsx` orchestrator (wallet writes, refresh, activity); `views/*` (Holdings, Shareholders, StockClasses, IssueStock, TransferStock, Transactions); `forms/*` (domain forms: Issuer, Stakeholder, StockClass, IssueStock, TransferStock, MintActions, IssuerHeader, HoldingsTable); `OwnershipBoxes`, `SetupChecklist`, `ownershipModel`, `types`
+  - `cap-table/` — `CapTableDashboard.tsx` shell (heal/reconcile/refresh/activity + wallet writes). Screens match the COMPANY left nav: `Holdings`, `StockClasses`, `Shareholders`, `IssueStock`, `Transfer`, `Transactions`. `forms/*` are fields (Issuer, Stakeholder, StockClass, IssueStock, TransferStock, MintActions, IssuerHeader, HoldingsTable), not nav destinations. Also `OwnershipBoxes`, `SetupChecklist`, `ownershipModel`, `types`, `useWalletReceipt`, `useCapTableWrites`.
   - Shared list UI: `DataTable` + `Table` / `TableFrame` (full-width framed tables); `Modal`, `TxSuccessModal`
 - `e2e/` — Playwright specs + `mocks.ts` fixtures (`playwright.config.ts` at app root)
 - `src/hooks/` — `useMintIssuer`, `useDirectCreateStockClass`, `useDirectCreateStakeholder`, `useDirectIssueStock`, **`useDirectTransferStock`**, `useOnchainAction`, `useResource`, `useCapTableManager`

--- a/app/src/components/cap-table/CapTableDashboard.tsx
+++ b/app/src/components/cap-table/CapTableDashboard.tsx
@@ -6,80 +6,36 @@ import { IssuerHeader } from "./forms/IssuerHeader";
 import { HoldingsTable } from "./forms/HoldingsTable";
 import { TxSuccessModal } from "../TxSuccessModal";
 import { useCapTableManager } from "../../hooks/useCapTableManager";
-import { useDirectCreateStockClass } from "../../hooks/useDirectCreateStockClass";
-import { useDirectCreateStakeholder } from "../../hooks/useDirectCreateStakeholder";
-import { useDirectIssueStock } from "../../hooks/useDirectIssueStock";
-import { useDirectTransferStock } from "../../hooks/useDirectTransferStock";
-import { bytes16ToUuid, generateBytes16Id } from "../../utils/uuid";
-import { validateShareCaps } from "@tap/units";
 import { fetchHistoricalTransactions } from "../../services/fetchHistoricalTransactions";
-import { registerStockClassOnchain, type StockClassData } from "../../services/createStockClass";
-import { registerStakeholderOnchain, type StakeholderData } from "../../services/createStakeholder";
-import { registerStockIssuanceOnchain, type StockIssuanceData } from "../../services/createStockIssuance";
 import type { IssuerResponse } from "../../services/registerIssuer";
 import { copy } from "../../lib/copy";
 import { capTableHref, parseCapTableView, type CapTableView } from "../shell/navConfig";
 import { issuanceStillSyncing } from "../../utils/holdingStatus";
-import {
-	appendActivity,
-	loadActivity,
-	markActivityByTx,
-	updateActivity,
-	type ActivityEntry,
-} from "../../utils/activityLog";
-import type { TransferStockFormData } from "./forms/TransferStockForm";
+import { loadActivity, type ActivityEntry } from "../../utils/activityLog";
 import {
 	dedupeById,
 	type CapTableDashboardProps,
-	type OptimisticIssuance,
-	type OptimisticStakeholder,
-	type OptimisticStockClass,
 	type SuccessModalState,
 } from "./types";
 import { CapTableToolbar } from "./CapTableToolbar";
-import { HoldingsView } from "./views/HoldingsView";
-import { ShareholdersView } from "./views/ShareholdersView";
-import { StockClassesView } from "./views/StockClassesView";
-import { IssueStockView } from "./views/IssueStockView";
-import { TransferStockView } from "./views/TransferStockView";
-import { TransactionsView } from "./views/TransactionsView";
+import { useCapTableWrites } from "./useCapTableWrites";
+import { Holdings } from "./Holdings";
+import { Shareholders } from "./Shareholders";
+import { StockClasses } from "./StockClasses";
+import { IssueStock } from "./IssueStock";
+import { Transfer } from "./Transfer";
+import { Transactions } from "./Transactions";
 
 /**
- * Company cap-table workspace orchestrator.
- * Views live under ./views; this file owns wallet writes + server refresh.
+ * Company workspace shell. Left-nav screens are sibling modules named after
+ * the COMPANY section: Holdings, Stock classes, Shareholders, Issue stock,
+ * Transfer, Transactions.
  */
 export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardProps) {
 	const router = useRouter();
 	const currentView: CapTableView = parseCapTableView(router.query.view as string | undefined);
 
-	const directStockClass = useDirectCreateStockClass();
-	const directStakeholder = useDirectCreateStakeholder();
-	const directIssuance = useDirectIssueStock();
-	const directTransfer = useDirectTransferStock();
-
-	// Prefer live holdings.issuer.deployed_to when the page hydrated without it
-	// (stale localStorage) so writes and the header use the real contract.
-
-	const [directStockClasses, setDirectStockClasses] = useState<OptimisticStockClass[]>([]);
-	const [directStakeholders, setDirectStakeholders] = useState<OptimisticStakeholder[]>([]);
-	const [directIssuances, setDirectIssuances] = useState<OptimisticIssuance[]>([]);
-
-	const [pendingStockClass, setPendingStockClass] = useState(false);
-	const [pendingStakeholder, setPendingStakeholder] = useState(false);
-	const [pendingIssuance, setPendingIssuance] = useState(false);
-	const [pendingTransfer, setPendingTransfer] = useState(false);
-
 	const [successModal, setSuccessModal] = useState<SuccessModalState | null>(null);
-
-	const [pendingStockClassMeta, setPendingStockClassMeta] = useState<{
-		id: string;
-		data: StockClassData;
-	} | null>(null);
-	const [pendingStakeholderMeta, setPendingStakeholderMeta] = useState<{
-		id: string;
-		data: StakeholderData;
-	} | null>(null);
-
 	const [historicalTransactions, setHistoricalTransactions] = useState<any[]>([]);
 	const [activityLog, setActivityLog] = useState<ActivityEntry[]>([]);
 	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -87,10 +43,8 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 	const [syncNote, setSyncNote] = useState<string | null>(null);
 	const [addingShareholder, setAddingShareholder] = useState(false);
 	const [addingStockClass, setAddingStockClass] = useState(false);
-	const [pendingActivityId, setPendingActivityId] = useState<string | null>(null);
 	const [hasPendingSyncFlag, setHasPendingSyncFlag] = useState(false);
 
-	// Self-heal: if page hydrated without deployed_to, re-fetch full issuer once
 	const [healedIssuer, setHealedIssuer] = useState<IssuerResponse | null>(null);
 	useEffect(() => {
 		if (!issuerResult?._id) return;
@@ -134,37 +88,20 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		""
 	) as `0x${string}` | "";
 
-	const requireWriteReady = (): boolean => {
-		const connected =
-			directStockClass.isConnected ||
-			directStakeholder.isConnected ||
-			directIssuance.isConnected ||
-			directTransfer.isConnected;
-		if (!connected) {
-			setSuccessModal({
-				title: "Wallet required",
-				message: copy.tx.walletRequired,
-				variant: "info",
-			});
-			return false;
-		}
-		if (!capTableAddress || !capTableAddress.startsWith("0x")) {
-			setSuccessModal({
-				title: "Contract missing",
-				message: copy.tx.contractMissing,
-				variant: "error",
-			});
-			return false;
-		}
-		return true;
-	};
+	const writes = useCapTableWrites({
+		issuerId: issuerResult._id,
+		capTableAddress,
+		holdings: manager.holdings,
+		refreshHoldings: manager.refreshHoldings,
+		setSuccessModal,
+		setActivityLog,
+	});
 
 	useEffect(() => {
 		if (!effectiveIssuer?._id) return;
 		setActivityLog(loadActivity(effectiveIssuer._id));
 	}, [effectiveIssuer?._id]);
 
-	// Soft reconcile on open (ghost flags + missing TX hashes)
 	useEffect(() => {
 		if (!effectiveIssuer?._id) return;
 		let cancelled = false;
@@ -195,254 +132,6 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		};
 	}, [effectiveIssuer?._id]);
 
-	// Stock class receipt
-	useEffect(() => {
-		if (!pendingStockClass) return;
-		if (directStockClass.isConfirmed) {
-			const hash = directStockClass.hash;
-			setSuccessModal({
-				title: copy.tx.confirmedTitle.stockClass,
-				txHash: hash,
-				variant: "success",
-			});
-			setDirectStockClasses((prev) =>
-				prev.map((sc, i) => (i === prev.length - 1 ? { ...sc, onchain: true } : sc)),
-			);
-			if (pendingStockClassMeta) {
-				registerStockClassOnchain({
-					issuerId: issuerResult._id,
-					data: pendingStockClassMeta.data,
-					id: pendingStockClassMeta.id,
-					tx_hash: hash || undefined,
-				}).catch((err) => console.warn("Failed to register stock class metadata:", err));
-				setPendingStockClassMeta(null);
-			}
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, {
-						status: "confirmed",
-						txHash: hash || undefined,
-					}),
-				);
-			} else if (hash && issuerResult._id) {
-				setActivityLog(markActivityByTx(issuerResult._id, hash, "confirmed"));
-			}
-			setPendingActivityId(null);
-			setPendingStockClass(false);
-			directStockClass.reset();
-			manager.refreshHoldings();
-		} else if (directStockClass.isReverted) {
-			setSuccessModal({
-				title: copy.tx.revertedTitle,
-				message: directStockClass.errorMessage || copy.tx.revertedGeneric,
-				variant: "error",
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, { status: "reverted" }),
-				);
-			}
-			setDirectStockClasses((prev) => prev.slice(0, -1));
-			setPendingStockClassMeta(null);
-			setPendingActivityId(null);
-			setPendingStockClass(false);
-			directStockClass.reset();
-		}
-	}, [
-		directStockClass.isConfirmed,
-		directStockClass.isReverted,
-		directStockClass.hash,
-		pendingStockClass,
-		directStockClass,
-		pendingActivityId,
-		issuerResult._id,
-		pendingStockClassMeta,
-		manager,
-	]);
-
-	// Shareholder receipt
-	useEffect(() => {
-		if (!pendingStakeholder) return;
-		if (directStakeholder.isConfirmed) {
-			const hash = directStakeholder.hash;
-			setSuccessModal({
-				title: copy.tx.confirmedTitle.stakeholder,
-				txHash: hash,
-				variant: "success",
-			});
-			if (pendingStakeholderMeta) {
-				registerStakeholderOnchain({
-					issuerId: issuerResult._id,
-					data: pendingStakeholderMeta.data,
-					id: pendingStakeholderMeta.id,
-					tx_hash: hash || undefined,
-				}).catch((err) => console.warn("Failed to register stakeholder metadata:", err));
-				setPendingStakeholderMeta(null);
-			}
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, {
-						status: "confirmed",
-						txHash: hash || undefined,
-					}),
-				);
-			} else if (hash && issuerResult._id) {
-				setActivityLog(markActivityByTx(issuerResult._id, hash, "confirmed"));
-			}
-			setPendingActivityId(null);
-			setPendingStakeholder(false);
-			directStakeholder.reset();
-			manager.refreshHoldings();
-		} else if (directStakeholder.isReverted) {
-			setSuccessModal({
-				title: copy.tx.revertedTitle,
-				message: directStakeholder.errorMessage || copy.tx.revertedGeneric,
-				variant: "error",
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, { status: "reverted" }),
-				);
-			}
-			setDirectStakeholders((prev) => prev.slice(0, -1));
-			setPendingStakeholderMeta(null);
-			setPendingActivityId(null);
-			setPendingStakeholder(false);
-			directStakeholder.reset();
-		}
-	}, [
-		directStakeholder.isConfirmed,
-		directStakeholder.isReverted,
-		directStakeholder.hash,
-		pendingStakeholder,
-		directStakeholder,
-		pendingActivityId,
-		issuerResult._id,
-		pendingStakeholderMeta,
-		manager,
-	]);
-
-	// Issuance receipt
-	useEffect(() => {
-		if (!pendingIssuance) return;
-		if (directIssuance.isConfirmed) {
-			const hash = directIssuance.hash;
-			setSuccessModal({
-				title: copy.tx.confirmedTitle.issuance,
-				txHash: hash,
-			});
-			setDirectIssuances((prev) => {
-				if (!prev.length) return prev;
-				const next = [...prev];
-				next[next.length - 1] = {
-					...next[next.length - 1],
-					txHash: hash || next[next.length - 1].txHash,
-					confirmed: true,
-				};
-				return next;
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, {
-						status: "confirmed",
-						txHash: hash || undefined,
-					}),
-				);
-			} else if (hash && issuerResult._id) {
-				setActivityLog(markActivityByTx(issuerResult._id, hash, "confirmed"));
-			}
-			setPendingActivityId(null);
-			setPendingIssuance(false);
-			directIssuance.reset();
-			manager.refreshHoldings();
-			const t1 = setTimeout(() => manager.refreshHoldings(), 1500);
-			const t2 = setTimeout(() => manager.refreshHoldings(), 4000);
-			return () => {
-				clearTimeout(t1);
-				clearTimeout(t2);
-			};
-		} else if (directIssuance.isReverted) {
-			setSuccessModal({
-				title: copy.tx.revertedTitle,
-				message: directIssuance.errorMessage || copy.tx.issuanceReverted,
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, { status: "reverted" }),
-				);
-			}
-			setDirectIssuances((prev) => prev.slice(0, -1));
-			setPendingActivityId(null);
-			setPendingIssuance(false);
-			directIssuance.reset();
-		}
-	}, [
-		directIssuance.isConfirmed,
-		directIssuance.isReverted,
-		directIssuance.hash,
-		pendingIssuance,
-		directIssuance,
-		manager,
-		pendingActivityId,
-		issuerResult._id,
-	]);
-
-	// Transfer receipt
-	useEffect(() => {
-		if (!pendingTransfer) return;
-		if (directTransfer.isConfirmed) {
-			const hash = directTransfer.hash;
-			setSuccessModal({
-				title: copy.transfer.confirmedTitle,
-				txHash: hash,
-				variant: "success",
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, {
-						status: "confirmed",
-						txHash: hash || undefined,
-					}),
-				);
-			} else if (hash && issuerResult._id) {
-				setActivityLog(markActivityByTx(issuerResult._id, hash, "confirmed"));
-			}
-			setPendingActivityId(null);
-			setPendingTransfer(false);
-			directTransfer.reset();
-			manager.refreshHoldings();
-			const t1 = setTimeout(() => manager.refreshHoldings(), 1500);
-			const t2 = setTimeout(() => manager.refreshHoldings(), 4000);
-			return () => {
-				clearTimeout(t1);
-				clearTimeout(t2);
-			};
-		} else if (directTransfer.isReverted) {
-			setSuccessModal({
-				title: copy.tx.revertedTitle,
-				message: directTransfer.errorMessage || copy.tx.revertedGeneric,
-				variant: "error",
-			});
-			if (pendingActivityId && issuerResult._id) {
-				setActivityLog(
-					updateActivity(issuerResult._id, pendingActivityId, { status: "reverted" }),
-				);
-			}
-			setPendingActivityId(null);
-			setPendingTransfer(false);
-			directTransfer.reset();
-		}
-	}, [
-		directTransfer.isConfirmed,
-		directTransfer.isReverted,
-		directTransfer.hash,
-		pendingTransfer,
-		directTransfer,
-		manager,
-		pendingActivityId,
-		issuerResult._id,
-	]);
-
 	const loadHistory = useCallback(() => {
 		if (!issuerResult?._id) return;
 		setIsLoadingHistory(true);
@@ -463,31 +152,31 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		if (currentView === "transactions" || currentView === "overview") {
 			loadHistory();
 		}
-	}, [currentView, loadHistory, directIssuances.length]);
+	}, [currentView, loadHistory, writes.directIssuances.length]);
 
 	const stockClassOptions = useMemo(() => {
 		const fromHoldings = manager.holdings?.stockClasses || [];
-		return dedupeById([...fromHoldings, ...directStockClasses]);
-	}, [manager.holdings?.stockClasses, directStockClasses]);
+		return dedupeById([...fromHoldings, ...writes.directStockClasses]);
+	}, [manager.holdings?.stockClasses, writes.directStockClasses]);
 
 	const issuableStockClasses = useMemo(() => {
 		return stockClassOptions.filter((sc: any) => {
 			if (sc.onchain) return true;
 			if (sc.is_onchain_synced === true) return true;
-			const session = directStockClasses.find((d) => d._id === sc._id);
+			const session = writes.directStockClasses.find((d) => d._id === sc._id);
 			if (session) return !!session.onchain;
 			if (sc.is_onchain_synced === false) return false;
 			return true;
 		});
-	}, [stockClassOptions, directStockClasses]);
+	}, [stockClassOptions, writes.directStockClasses]);
 
 	const stakeholderOptions = useMemo(() => {
 		const fromServer = manager.holdings?.stakeholders || [];
 		const fromHoldings = (manager.holdings?.holdings || [])
 			.map((h: { stakeholder?: any }) => h.stakeholder)
 			.filter(Boolean);
-		return dedupeById([...fromServer, ...fromHoldings, ...directStakeholders]);
-	}, [manager.holdings?.stakeholders, manager.holdings?.holdings, directStakeholders]);
+		return dedupeById([...fromServer, ...fromHoldings, ...writes.directStakeholders]);
+	}, [manager.holdings?.stakeholders, manager.holdings?.holdings, writes.directStakeholders]);
 
 	const syncedHoldingKeys = new Set(
 		(manager.holdings?.holdings || []).map(
@@ -495,11 +184,11 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		),
 	);
 	const hasPendingSync =
-		pendingStockClass ||
-		pendingStakeholder ||
-		pendingIssuance ||
-		pendingTransfer ||
-		directIssuances.some((iss) => issuanceStillSyncing(iss, syncedHoldingKeys));
+		writes.pendingStockClass ||
+		writes.pendingStakeholder ||
+		writes.pendingIssuance ||
+		writes.pendingTransfer ||
+		writes.directIssuances.some((iss) => issuanceStillSyncing(iss, syncedHoldingKeys));
 
 	useEffect(() => {
 		setHasPendingSyncFlag(hasPendingSync);
@@ -544,296 +233,15 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		}
 	};
 
-	const handleStockClass = async (data: StockClassData) => {
-		if (!requireWriteReady()) return;
-		try {
-			const stockClassBytes16 = generateBytes16Id() as `0x${string}`;
-			const stockClassUuid = bytes16ToUuid(stockClassBytes16);
-			const result = await directStockClass.createStockClass({
-				capTableAddress: capTableAddress as `0x${string}`,
-				classType: data.class_type,
-				pricePerShareAmount: data.price_per_share?.amount || "0",
-				initialSharesAuthorized: data.initial_shares_authorized,
-				id: stockClassBytes16,
-			});
-			const activityId = `sc-${stockClassUuid}-${Date.now()}`;
-			setPendingActivityId(activityId);
-			setPendingStockClass(true);
-			setPendingStockClassMeta({ id: stockClassUuid, data });
-			setDirectStockClasses((prev) => [
-				...prev,
-				{
-					_id: stockClassUuid,
-					name: data.name,
-					class_type: data.class_type,
-					initial_shares_authorized: data.initial_shares_authorized,
-					onchain: false,
-				},
-			]);
-			setActivityLog(
-				appendActivity(issuerResult._id, {
-					id: activityId,
-					issuerId: issuerResult._id,
-					kind: "stock_class",
-					type: "Stock class created",
-					details: data.name,
-					date: new Date().toISOString().slice(0, 10),
-					txHash: result.hash,
-					status: "pending",
-					createdAt: Date.now(),
-				}),
-			);
-		} catch (err) {
-			setSuccessModal({
-				title: "Transaction failed",
-				message: err instanceof Error ? err.message : "Failed to create share class.",
-				variant: "error",
-			});
-		}
-	};
-
-	const handleStakeholder = async (data: StakeholderData) => {
-		if (!requireWriteReady()) return;
-		try {
-			const stakeholderBytes16 = generateBytes16Id() as `0x${string}`;
-			const stakeholderUuid = bytes16ToUuid(stakeholderBytes16);
-			const result = await directStakeholder.createStakeholder({
-				capTableAddress: capTableAddress as `0x${string}`,
-				stakeholderType: data.stakeholder_type,
-				currentRelationship: data.current_relationship,
-				id: stakeholderBytes16,
-			});
-			const activityId = `sh-${stakeholderUuid}-${Date.now()}`;
-			const legalName = data.name?.legal_name || "Shareholder";
-			setPendingActivityId(activityId);
-			setPendingStakeholder(true);
-			setPendingStakeholderMeta({ id: stakeholderUuid, data });
-			setDirectStakeholders((prev) => [
-				...prev,
-				{
-					_id: stakeholderUuid,
-					name: data.name,
-					stakeholder_type: data.stakeholder_type,
-					current_relationship: data.current_relationship,
-				},
-			]);
-			setActivityLog(
-				appendActivity(issuerResult._id, {
-					id: activityId,
-					issuerId: issuerResult._id,
-					kind: "stakeholder",
-					type: "Shareholder created",
-					details: legalName,
-					date: new Date().toISOString().slice(0, 10),
-					txHash: result.hash,
-					status: "pending",
-					createdAt: Date.now(),
-				}),
-			);
-		} catch (err) {
-			setSuccessModal({
-				title: "Transaction failed",
-				message: err instanceof Error ? err.message : "Failed to add shareholder.",
-				variant: "error",
-			});
-		}
-	};
-
-	const handleIssuance = async (data: StockIssuanceData) => {
-		if (!requireWriteReady()) return;
-
-		const issuer = manager.holdings?.issuer;
-		const stockClass =
-			stockClassOptions.find((sc: any) => sc._id === data.stock_class_id) ||
-			(manager.holdings?.stockClasses || []).find((sc: any) => sc._id === data.stock_class_id);
-		const stakeholder = stakeholderOptions.find((sh: any) => sh._id === data.stakeholder_id);
-
-		const cap = validateShareCaps({
-			quantity: data.quantity,
-			issuerAuthorized: issuer?.initial_shares_authorized ?? 0,
-			issuerIssued: (manager.holdings?.holdings || []).reduce(
-				(sum: number, h: any) => sum + (Number(h.quantity) || 0),
-				0,
-			),
-			classAuthorized: stockClass?.initial_shares_authorized ?? stockClass?.shares_authorized,
-			classIssued: (manager.holdings?.holdings || [])
-				.filter((h: any) => h.stockClass?._id === data.stock_class_id)
-				.reduce((sum: number, h: any) => sum + (Number(h.quantity) || 0), 0),
-		});
-
-		if (!cap.ok) {
-			setSuccessModal({ title: "Not enough shares", message: cap.errors.join(" ") });
-			return;
-		}
-
-		try {
-			const sessionClass = directStockClasses.find((d) => d._id === data.stock_class_id);
-			const onchainOk =
-				sessionClass?.onchain === true ||
-				stockClass?.is_onchain_synced === true ||
-				(stockClass?.is_onchain_synced !== false && !sessionClass && !!stockClass);
-			if (!onchainOk || stockClass?.is_onchain_synced === false) {
-				if (!sessionClass?.onchain) {
-					setSuccessModal({
-						title: "Stock class isn’t ready yet",
-						message:
-							"Go to Stock classes, create the class, and confirm in your wallet. Then come back to Issue stock.",
-						variant: "info",
-					});
-					return;
-				}
-			}
-
-			const result = await directIssuance.issueStock({
-				capTableAddress: capTableAddress as `0x${string}`,
-				stakeholderId: data.stakeholder_id,
-				stockClassId: data.stock_class_id,
-				quantity: data.quantity,
-				sharePriceAmount: data.share_price?.amount || "0",
-				customId: data.custom_id,
-				comments: data.comments,
-			});
-
-			const activityId = `iss-${result.issuanceId}-${Date.now()}`;
-			const holderName =
-				stakeholder?.name?.legal_name || stakeholder?.name?.first_name || "Holder";
-			const className = stockClass?.name || "Class";
-			setPendingActivityId(activityId);
-			setPendingIssuance(true);
-			setDirectIssuances((prev) => [
-				...prev,
-				{
-					_id: result.issuanceId,
-					security_id: result.securityId,
-					quantity: data.quantity,
-					stakeholder_id: data.stakeholder_id,
-					stock_class_id: data.stock_class_id,
-					share_price: data.share_price,
-					stakeholder_name: holderName,
-					stock_class_name: className,
-					custom_id: data.custom_id,
-					txHash: result.hash,
-					date: new Date().toISOString().slice(0, 10),
-				},
-			]);
-			setActivityLog(
-				appendActivity(issuerResult._id, {
-					id: activityId,
-					issuerId: issuerResult._id,
-					kind: "stock_issuance",
-					type: "Stock issued",
-					details: data.custom_id || `${holderName} · ${className}`,
-					quantity: data.quantity,
-					price: data.share_price?.amount
-						? `${data.share_price.amount} ${data.share_price.currency || "USD"}`
-						: undefined,
-					date: new Date().toISOString().slice(0, 10),
-					txHash: result.hash,
-					status: "pending",
-					createdAt: Date.now(),
-				}),
-			);
-
-			registerStockIssuanceOnchain({ issuerId: issuerResult._id, data }).catch((err) =>
-				console.warn("Failed to register stock issuance metadata:", err),
-			);
-			manager.refreshHoldings();
-		} catch (err) {
-			setSuccessModal({
-				title: "Transaction failed",
-				message: err instanceof Error ? err.message : "Failed to issue stock.",
-				variant: "error",
-			});
-		}
-	};
-
-	const handleTransfer = async (data: TransferStockFormData) => {
-		if (!requireWriteReady()) return;
-
-		const from = stakeholderOptions.find((s: any) => s._id === data.transferor_id);
-		const to = stakeholderOptions.find((s: any) => s._id === data.transferee_id);
-		const sc =
-			stockClassOptions.find((c: any) => c._id === data.stock_class_id) ||
-			(manager.holdings?.stockClasses || []).find((c: any) => c._id === data.stock_class_id);
-
-		const held = (manager.holdings?.holdings || [])
-			.filter(
-				(h: any) =>
-					h.stakeholder?._id === data.transferor_id &&
-					h.stockClass?._id === data.stock_class_id,
-			)
-			.reduce((sum: number, h: any) => sum + (Number(h.quantity) || 0), 0);
-
-		const qty = Number(data.quantity);
-		if (!Number.isFinite(qty) || qty <= 0) {
-			setSuccessModal({
-				title: "Invalid quantity",
-				message: "Enter a positive number of shares to transfer.",
-				variant: "info",
-			});
-			return;
-		}
-		if (qty > held) {
-			setSuccessModal({
-				title: "Not enough shares",
-				message: `${from?.name?.legal_name || "Transferor"} only holds ${held.toLocaleString()} of this class.`,
-				variant: "info",
-			});
-			return;
-		}
-
-		try {
-			const result = await directTransfer.transferStock({
-				capTableAddress: capTableAddress as `0x${string}`,
-				transferorId: data.transferor_id,
-				transfereeId: data.transferee_id,
-				stockClassId: data.stock_class_id,
-				quantity: data.quantity,
-				sharePriceAmount: data.share_price?.amount || "0",
-			});
-
-			const fromName = from?.name?.legal_name || "From";
-			const toName = to?.name?.legal_name || "To";
-			const className = sc?.name || "Class";
-			const activityId = `xfer-${data.transferor_id.slice(0, 8)}-${Date.now()}`;
-			setPendingActivityId(activityId);
-			setPendingTransfer(true);
-			setActivityLog(
-				appendActivity(issuerResult._id, {
-					id: activityId,
-					issuerId: issuerResult._id,
-					kind: "stock_transfer",
-					type: "Stock transferred",
-					details: `${fromName} → ${toName} · ${className}`,
-					quantity: data.quantity,
-					price: data.share_price?.amount
-						? `${data.share_price.amount} ${data.share_price.currency || "USD"}`
-						: undefined,
-					date: new Date().toISOString().slice(0, 10),
-					txHash: result.hash,
-					status: "pending",
-					createdAt: Date.now(),
-				}),
-			);
-			manager.refreshHoldings();
-		} catch (err) {
-			setSuccessModal({
-				title: "Transaction failed",
-				message: err instanceof Error ? err.message : "Failed to transfer stock.",
-				variant: "error",
-			});
-		}
-	};
-
 	const onchainClassCount = issuableStockClasses.length;
 	const peopleCount = stakeholderOptions.length;
 	const positionCount =
 		(manager.holdings?.holdings || []).length +
-		directIssuances.filter((i) => i.confirmed || i.txHash).length;
+		writes.directIssuances.filter((i) => i.confirmed || i.txHash).length;
 	const ghostClassCount = stockClassOptions.length - onchainClassCount;
 
 	const holdingsEmptyHint =
-		positionCount === 0 && directIssuances.length === 0
+		positionCount === 0 && writes.directIssuances.length === 0
 			? onchainClassCount === 0
 				? "Nothing issued yet. Create a stock class, add a shareholder, then issue stock."
 				: peopleCount === 0
@@ -855,9 +263,9 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 	const holdingsTable = (
 		<HoldingsTable
 			holdingsData={manager.holdings}
-			createdStockClasses={directStockClasses}
-			createdStakeholders={directStakeholders}
-			createdIssuances={directIssuances}
+			createdStockClasses={writes.directStockClasses}
+			createdStakeholders={writes.directStakeholders}
+			createdIssuances={writes.directIssuances}
 			isLoading={manager.isLoadingHoldings}
 			error={manager.holdingsError}
 			emptyHint={holdingsEmptyHint}
@@ -867,23 +275,23 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 	let main: ReactNode;
 	if (currentView === "stock-classes") {
 		main = (
-			<StockClassesView
+			<StockClasses
 				stockClasses={stockClassOptions}
-				sessionClasses={directStockClasses}
+				sessionClasses={writes.directStockClasses}
 				activityLog={activityLog}
 				ghostClassCount={ghostClassCount}
 				isLoading={manager.isLoadingHoldings}
 				syncNote={syncNote}
 				adding={addingStockClass}
 				onAddingChange={setAddingStockClass}
-				onSubmit={handleStockClass}
+				onSubmit={writes.handleStockClass}
 				toolbar={toolbar}
 				holdings={manager.holdings?.holdings || []}
 			/>
 		);
 	} else if (currentView === "stakeholders") {
 		main = (
-			<ShareholdersView
+			<Shareholders
 				stakeholders={stakeholderOptions}
 				activityLog={activityLog}
 				isLoading={manager.isLoadingHoldings}
@@ -891,36 +299,36 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 				holdings={manager.holdings?.holdings || []}
 				adding={addingShareholder}
 				onAddingChange={setAddingShareholder}
-				onSubmit={handleStakeholder}
+				onSubmit={writes.handleStakeholder}
 				toolbar={toolbar}
 			/>
 		);
 	} else if (currentView === "issue-stock") {
 		main = (
-			<IssueStockView
+			<IssueStock
 				stockClasses={issuableStockClasses}
 				stakeholders={stakeholderOptions}
 				isLoading={manager.isLoadingHoldings}
 				syncNote={syncNote}
-				onSubmit={handleIssuance}
+				onSubmit={writes.handleIssuance}
 				toolbar={toolbar}
 			/>
 		);
 	} else if (currentView === "transfer-stock") {
 		main = (
-			<TransferStockView
+			<Transfer
 				stakeholders={stakeholderOptions}
 				stockClasses={stockClassOptions}
 				holdings={manager.holdings?.holdings || []}
 				isLoading={manager.isLoadingHoldings}
 				syncNote={syncNote}
-				onSubmit={handleTransfer}
+				onSubmit={writes.handleTransfer}
 				toolbar={toolbar}
 			/>
 		);
 	} else if (currentView === "transactions") {
 		main = (
-			<TransactionsView
+			<Transactions
 				activityLog={activityLog}
 				historicalTransactions={historicalTransactions}
 				isLoadingHistory={isLoadingHistory}
@@ -930,7 +338,7 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 		);
 	} else {
 		main = (
-			<HoldingsView
+			<Holdings
 				positionCount={positionCount}
 				peopleCount={peopleCount}
 				onchainClassCount={onchainClassCount}
@@ -941,7 +349,7 @@ export function CapTableDashboard({ issuerResult, onReset }: CapTableDashboardPr
 				toolbar={toolbar}
 				holdingsTable={holdingsTable}
 				holdingsData={manager.holdings}
-				createdIssuances={directIssuances}
+				createdIssuances={writes.directIssuances}
 				onNavigate={goTo}
 			/>
 		);

--- a/app/src/components/cap-table/Holdings.tsx
+++ b/app/src/components/cap-table/Holdings.tsx
@@ -1,14 +1,14 @@
 import type { ReactNode } from "react";
-import { Section, SectionActions, SectionHeader, Stack } from "../../layout";
-import { Button, StatCard, StatGrid, StatLabel, StatValue, StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { copy } from "../../../lib/copy";
-import { SetupChecklist } from "../SetupChecklist";
-import { OwnershipBoxes } from "../OwnershipBoxes";
-import { buildOwnershipChart, formatPct, formatShares } from "../ownershipModel";
-import type { CapTableView } from "../../shell/navConfig";
+import { Section, SectionActions, SectionHeader, Stack } from "../layout";
+import { Button, StatCard, StatGrid, StatLabel, StatValue, StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { copy } from "../../lib/copy";
+import { SetupChecklist } from "./SetupChecklist";
+import { OwnershipBoxes } from "./OwnershipBoxes";
+import { buildOwnershipChart, formatPct, formatShares } from "./ownershipModel";
+import type { CapTableView } from "../shell/navConfig";
 
-interface HoldingsViewProps {
+export interface HoldingsProps {
 	positionCount: number;
 	peopleCount: number;
 	onchainClassCount: number;
@@ -31,7 +31,7 @@ interface HoldingsViewProps {
 	onNavigate: (view: CapTableView) => void;
 }
 
-export function HoldingsView({
+export function Holdings({
 	positionCount,
 	peopleCount,
 	onchainClassCount,
@@ -44,7 +44,7 @@ export function HoldingsView({
 	holdingsData,
 	createdIssuances = [],
 	onNavigate,
-}: HoldingsViewProps) {
+}: HoldingsProps) {
 	const showSetup = !isLoading && positionCount === 0;
 	const showBar = !isLoading && positionCount > 0;
 

--- a/app/src/components/cap-table/IssueStock.tsx
+++ b/app/src/components/cap-table/IssueStock.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
-import { Section, SectionHeader, Stack } from "../../layout";
-import { StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { IssueStockForm } from "../forms/IssueStockForm";
-import { copy } from "../../../lib/copy";
-import type { StockIssuanceData } from "../../../services/createStockIssuance";
+import { Section, SectionHeader, Stack } from "../layout";
+import { StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { IssueStockForm } from "./forms/IssueStockForm";
+import { copy } from "../../lib/copy";
+import type { StockIssuanceData } from "../../services/createStockIssuance";
 
-interface IssueStockViewProps {
+export interface IssueStockProps {
 	stockClasses: any[];
 	stakeholders: any[];
 	isLoading: boolean;
@@ -15,14 +15,14 @@ interface IssueStockViewProps {
 	toolbar: ReactNode;
 }
 
-export function IssueStockView({
+export function IssueStock({
 	stockClasses,
 	stakeholders,
 	isLoading,
 	syncNote,
 	onSubmit,
 	toolbar,
-}: IssueStockViewProps) {
+}: IssueStockProps) {
 	const disabled = isLoading || stockClasses.length === 0 || stakeholders.length === 0;
 	const hint =
 		!isLoading && stakeholders.length === 0

--- a/app/src/components/cap-table/Shareholders.tsx
+++ b/app/src/components/cap-table/Shareholders.tsx
@@ -1,15 +1,15 @@
 import { useState, type ReactNode } from "react";
 import styled from "styled-components";
-import { Section, SectionActions, SectionHeader, Stack } from "../../layout";
-import { Button, StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { TextInput } from "../../forms";
-import { DataTable, type Column } from "../../DataTable";
-import { StakeholderForm } from "../forms/StakeholderForm";
-import { copy, shortTx } from "../../../lib/copy";
-import type { StakeholderData } from "../../../services/createStakeholder";
-import { EXPLORER_TX, type ActivityEntry } from "../../../utils/activityLog";
-import { formatRelationship, formatStakeholderType } from "../types";
+import { Section, SectionActions, SectionHeader, Stack } from "../layout";
+import { Button, StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { TextInput } from "../forms";
+import { DataTable, type Column } from "../DataTable";
+import { StakeholderForm } from "./forms/StakeholderForm";
+import { copy, shortTx } from "../../lib/copy";
+import type { StakeholderData } from "../../services/createStakeholder";
+import { EXPLORER_TX, type ActivityEntry } from "../../utils/activityLog";
+import { formatRelationship, formatStakeholderType } from "./types";
 
 const SearchInput = styled(TextInput)`
 	max-width: 16rem;
@@ -17,7 +17,7 @@ const SearchInput = styled(TextInput)`
 	font-size: ${({ theme }) => theme.fontSizes.small};
 `;
 
-interface ShareholdersViewProps {
+export interface ShareholdersProps {
 	stakeholders: any[];
 	activityLog: ActivityEntry[];
 	isLoading: boolean;
@@ -86,7 +86,7 @@ const columns: Column<ShareholderRow>[] = [
 	{ key: "tx", header: "Transaction", width: "16%", render: (r) => r.tx },
 ];
 
-export function ShareholdersView({
+export function Shareholders({
 	stakeholders,
 	activityLog,
 	isLoading,
@@ -96,10 +96,9 @@ export function ShareholdersView({
 	onSubmit,
 	toolbar,
 	holdings = [],
-}: ShareholdersViewProps) {
+}: ShareholdersProps) {
 	const [query, setQuery] = useState("");
 
-	// Aggregate positions per shareholder for the Total shares / Holdings columns
 	const sharesByHolder = new Map<string, { total: number; count: number }>();
 	for (const h of holdings) {
 		const id = h.stakeholder?._id;

--- a/app/src/components/cap-table/StockClasses.tsx
+++ b/app/src/components/cap-table/StockClasses.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode } from "react";
-import { Section, SectionActions, SectionHeader, Stack } from "../../layout";
-import { Button, StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { DataTable, type Column } from "../../DataTable";
-import { StockClassForm } from "../forms/StockClassForm";
-import { copy, shortTx } from "../../../lib/copy";
-import type { StockClassData } from "../../../services/createStockClass";
-import { EXPLORER_TX, type ActivityEntry } from "../../../utils/activityLog";
-import { formatClassType, type OptimisticStockClass } from "../types";
+import { Section, SectionActions, SectionHeader, Stack } from "../layout";
+import { Button, StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { DataTable, type Column } from "../DataTable";
+import { StockClassForm } from "./forms/StockClassForm";
+import { copy, shortTx } from "../../lib/copy";
+import type { StockClassData } from "../../services/createStockClass";
+import { EXPLORER_TX, type ActivityEntry } from "../../utils/activityLog";
+import { formatClassType, type OptimisticStockClass } from "./types";
 
-interface StockClassesViewProps {
+export interface StockClassesProps {
 	stockClasses: any[];
 	sessionClasses: OptimisticStockClass[];
 	activityLog: ActivityEntry[];
@@ -77,7 +77,7 @@ const columns: Column<ClassRow>[] = [
 	{ key: "tx", header: "Transaction", width: "16%", render: (r) => r.tx },
 ];
 
-export function StockClassesView({
+export function StockClasses({
 	stockClasses,
 	sessionClasses,
 	activityLog,
@@ -89,8 +89,7 @@ export function StockClassesView({
 	onSubmit,
 	toolbar,
 	holdings = [],
-}: StockClassesViewProps) {
-	// Issued per class from current positions
+}: StockClassesProps) {
 	const issuedByClass = new Map<string, number>();
 	for (const h of holdings) {
 		const id = h.stockClass?._id;

--- a/app/src/components/cap-table/Transactions.tsx
+++ b/app/src/components/cap-table/Transactions.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
-import { Section, SectionHeader, Stack } from "../../layout";
-import { StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { DataTable, type Column } from "../../DataTable";
-import { copy, shortTx } from "../../../lib/copy";
-import { EXPLORER_TX, type ActivityEntry } from "../../../utils/activityLog";
+import { Section, SectionHeader, Stack } from "../layout";
+import { StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { DataTable, type Column } from "../DataTable";
+import { copy, shortTx } from "../../lib/copy";
+import { EXPLORER_TX, type ActivityEntry } from "../../utils/activityLog";
 
-interface TransactionsViewProps {
+export interface TransactionsProps {
 	activityLog: ActivityEntry[];
 	historicalTransactions: any[];
 	isLoadingHistory: boolean;
@@ -61,13 +61,13 @@ const columns: Column<TxRow>[] = [
 	{ key: "tx", header: copy.transactions.columns.tx, width: "14%", render: (r) => r.tx },
 ];
 
-export function TransactionsView({
+export function Transactions({
 	activityLog,
 	historicalTransactions,
 	isLoadingHistory,
 	syncNote,
 	toolbar,
-}: TransactionsViewProps) {
+}: TransactionsProps) {
 	const localRows: TxRow[] = activityLog.map((e) => ({
 		key: e.id,
 		type: copy.txTypeLabel(e.kind) || copy.txTypeLabel(e.type) || e.type,

--- a/app/src/components/cap-table/Transfer.tsx
+++ b/app/src/components/cap-table/Transfer.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
-import { Section, SectionHeader, Stack } from "../../layout";
-import { StatusMessage } from "../../elements";
-import { H3, MutedText } from "../../typography";
-import { TransferStockForm, type TransferStockFormData } from "../forms/TransferStockForm";
-import { copy } from "../../../lib/copy";
+import { Section, SectionHeader, Stack } from "../layout";
+import { StatusMessage } from "../elements";
+import { H3, MutedText } from "../typography";
+import { TransferStockForm, type TransferStockFormData } from "./forms/TransferStockForm";
+import { copy } from "../../lib/copy";
 
-interface TransferStockViewProps {
+export interface TransferProps {
 	stakeholders: any[];
 	stockClasses: any[];
 	holdings: any[];
@@ -15,7 +15,7 @@ interface TransferStockViewProps {
 	toolbar: ReactNode;
 }
 
-export function TransferStockView({
+export function Transfer({
 	stakeholders,
 	stockClasses,
 	holdings,
@@ -23,7 +23,7 @@ export function TransferStockView({
 	syncNote,
 	onSubmit,
 	toolbar,
-}: TransferStockViewProps) {
+}: TransferProps) {
 	const hasPositions = holdings.some((h) => Number(h.quantity) > 0);
 	const canTransfer = hasPositions && stakeholders.length >= 2;
 

--- a/app/src/components/cap-table/index.ts
+++ b/app/src/components/cap-table/index.ts
@@ -1,6 +1,6 @@
 /**
  * Cap-table feature module.
- * Orchestrator + views for the company workspace.
+ * CapTableDashboard is the company workspace shell; screens are named after the left nav.
  */
 export { CapTableDashboard } from "./CapTableDashboard";
 export type {

--- a/app/src/components/cap-table/useCapTableWrites.ts
+++ b/app/src/components/cap-table/useCapTableWrites.ts
@@ -1,0 +1,547 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from "react";
+import { validateShareCaps } from "@tap/units";
+import { useDirectCreateStockClass } from "../../hooks/useDirectCreateStockClass";
+import { useDirectCreateStakeholder } from "../../hooks/useDirectCreateStakeholder";
+import { useDirectIssueStock } from "../../hooks/useDirectIssueStock";
+import { useDirectTransferStock } from "../../hooks/useDirectTransferStock";
+import { bytes16ToUuid, generateBytes16Id } from "../../utils/uuid";
+import { registerStockClassOnchain, type StockClassData } from "../../services/createStockClass";
+import { registerStakeholderOnchain, type StakeholderData } from "../../services/createStakeholder";
+import { registerStockIssuanceOnchain, type StockIssuanceData } from "../../services/createStockIssuance";
+import { copy } from "../../lib/copy";
+import {
+	appendActivity,
+	type ActivityEntry,
+} from "../../utils/activityLog";
+import type { TransferStockFormData } from "./forms/TransferStockForm";
+import { useWalletReceipt } from "./useWalletReceipt";
+import type {
+	OptimisticIssuance,
+	OptimisticStakeholder,
+	OptimisticStockClass,
+	SuccessModalState,
+} from "./types";
+
+interface UseCapTableWritesArgs {
+	issuerId: string;
+	capTableAddress: `0x${string}` | "";
+	holdings: {
+		issuer?: any;
+		stockClasses?: any[];
+		stakeholders?: any[];
+		holdings?: any[];
+	} | null;
+	refreshHoldings: () => void;
+	setSuccessModal: (state: SuccessModalState | null) => void;
+	setActivityLog: Dispatch<SetStateAction<ActivityEntry[]>>;
+}
+
+export function useCapTableWrites({
+	issuerId,
+	capTableAddress,
+	holdings,
+	refreshHoldings,
+	setSuccessModal,
+	setActivityLog,
+}: UseCapTableWritesArgs) {
+	const directStockClass = useDirectCreateStockClass();
+	const directStakeholder = useDirectCreateStakeholder();
+	const directIssuance = useDirectIssueStock();
+	const directTransfer = useDirectTransferStock();
+
+	const [directStockClasses, setDirectStockClasses] = useState<OptimisticStockClass[]>([]);
+	const [directStakeholders, setDirectStakeholders] = useState<OptimisticStakeholder[]>([]);
+	const [directIssuances, setDirectIssuances] = useState<OptimisticIssuance[]>([]);
+
+	const [pendingStockClass, setPendingStockClass] = useState(false);
+	const [pendingStakeholder, setPendingStakeholder] = useState(false);
+	const [pendingIssuance, setPendingIssuance] = useState(false);
+	const [pendingTransfer, setPendingTransfer] = useState(false);
+
+	const [pendingStockClassMeta, setPendingStockClassMeta] = useState<{
+		id: string;
+		data: StockClassData;
+	} | null>(null);
+	const [pendingStakeholderMeta, setPendingStakeholderMeta] = useState<{
+		id: string;
+		data: StakeholderData;
+	} | null>(null);
+	const [pendingActivityId, setPendingActivityId] = useState<string | null>(null);
+
+	const requireWriteReady = (): boolean => {
+		const connected =
+			directStockClass.isConnected ||
+			directStakeholder.isConnected ||
+			directIssuance.isConnected ||
+			directTransfer.isConnected;
+		if (!connected) {
+			setSuccessModal({
+				title: "Wallet required",
+				message: copy.tx.walletRequired,
+				variant: "info",
+			});
+			return false;
+		}
+		if (!capTableAddress || !capTableAddress.startsWith("0x")) {
+			setSuccessModal({
+				title: "Contract missing",
+				message: copy.tx.contractMissing,
+				variant: "error",
+			});
+			return false;
+		}
+		return true;
+	};
+
+	const pushActivity = (entry: ActivityEntry) => {
+		setActivityLog(appendActivity(issuerId, entry));
+	};
+
+	useWalletReceipt({
+		pending: pendingStockClass,
+		action: directStockClass,
+		issuerId,
+		pendingActivityId,
+		setPendingActivityId,
+		setActivityLog,
+		setSuccessModal,
+		clearPending: () => setPendingStockClass(false),
+		refreshHoldings,
+		confirmed: { title: copy.tx.confirmedTitle.stockClass, variant: "success" },
+		reverted: {
+			title: copy.tx.revertedTitle,
+			message: copy.tx.revertedGeneric,
+			variant: "error",
+		},
+		onConfirmed: (hash) => {
+			setDirectStockClasses((prev) =>
+				prev.map((sc, i) => (i === prev.length - 1 ? { ...sc, onchain: true } : sc)),
+			);
+			if (pendingStockClassMeta) {
+				registerStockClassOnchain({
+					issuerId,
+					data: pendingStockClassMeta.data,
+					id: pendingStockClassMeta.id,
+					tx_hash: hash || undefined,
+				}).catch((err) => console.warn("Failed to register stock class metadata:", err));
+				setPendingStockClassMeta(null);
+			}
+		},
+		onReverted: () => {
+			setDirectStockClasses((prev) => prev.slice(0, -1));
+			setPendingStockClassMeta(null);
+		},
+	});
+
+	useWalletReceipt({
+		pending: pendingStakeholder,
+		action: directStakeholder,
+		issuerId,
+		pendingActivityId,
+		setPendingActivityId,
+		setActivityLog,
+		setSuccessModal,
+		clearPending: () => setPendingStakeholder(false),
+		refreshHoldings,
+		confirmed: { title: copy.tx.confirmedTitle.stakeholder, variant: "success" },
+		reverted: {
+			title: copy.tx.revertedTitle,
+			message: copy.tx.revertedGeneric,
+			variant: "error",
+		},
+		onConfirmed: (hash) => {
+			if (pendingStakeholderMeta) {
+				registerStakeholderOnchain({
+					issuerId,
+					data: pendingStakeholderMeta.data,
+					id: pendingStakeholderMeta.id,
+					tx_hash: hash || undefined,
+				}).catch((err) => console.warn("Failed to register stakeholder metadata:", err));
+				setPendingStakeholderMeta(null);
+			}
+		},
+		onReverted: () => {
+			setDirectStakeholders((prev) => prev.slice(0, -1));
+			setPendingStakeholderMeta(null);
+		},
+	});
+
+	useWalletReceipt({
+		pending: pendingIssuance,
+		action: directIssuance,
+		issuerId,
+		pendingActivityId,
+		setPendingActivityId,
+		setActivityLog,
+		setSuccessModal,
+		clearPending: () => setPendingIssuance(false),
+		refreshHoldings,
+		delayedRefresh: true,
+		confirmed: { title: copy.tx.confirmedTitle.issuance },
+		reverted: {
+			title: copy.tx.revertedTitle,
+			message: copy.tx.issuanceReverted,
+		},
+		onConfirmed: (hash) => {
+			setDirectIssuances((prev) => {
+				if (!prev.length) return prev;
+				const next = [...prev];
+				next[next.length - 1] = {
+					...next[next.length - 1],
+					txHash: hash || next[next.length - 1].txHash,
+					confirmed: true,
+				};
+				return next;
+			});
+		},
+		onReverted: () => {
+			setDirectIssuances((prev) => prev.slice(0, -1));
+		},
+	});
+
+	useWalletReceipt({
+		pending: pendingTransfer,
+		action: directTransfer,
+		issuerId,
+		pendingActivityId,
+		setPendingActivityId,
+		setActivityLog,
+		setSuccessModal,
+		clearPending: () => setPendingTransfer(false),
+		refreshHoldings,
+		delayedRefresh: true,
+		confirmed: { title: copy.transfer.confirmedTitle, variant: "success" },
+		reverted: {
+			title: copy.tx.revertedTitle,
+			message: copy.tx.revertedGeneric,
+			variant: "error",
+		},
+	});
+
+	const handleStockClass = useCallback(
+		async (data: StockClassData) => {
+			if (!requireWriteReady()) return;
+			try {
+				const stockClassBytes16 = generateBytes16Id() as `0x${string}`;
+				const stockClassUuid = bytes16ToUuid(stockClassBytes16);
+				const result = await directStockClass.createStockClass({
+					capTableAddress: capTableAddress as `0x${string}`,
+					classType: data.class_type,
+					pricePerShareAmount: data.price_per_share?.amount || "0",
+					initialSharesAuthorized: data.initial_shares_authorized,
+					id: stockClassBytes16,
+				});
+				const activityId = `sc-${stockClassUuid}-${Date.now()}`;
+				setPendingActivityId(activityId);
+				setPendingStockClass(true);
+				setPendingStockClassMeta({ id: stockClassUuid, data });
+				setDirectStockClasses((prev) => [
+					...prev,
+					{
+						_id: stockClassUuid,
+						name: data.name,
+						class_type: data.class_type,
+						initial_shares_authorized: data.initial_shares_authorized,
+						onchain: false,
+					},
+				]);
+				pushActivity({
+					id: activityId,
+					issuerId,
+					kind: "stock_class",
+					type: "Stock class created",
+					details: data.name,
+					date: new Date().toISOString().slice(0, 10),
+					txHash: result.hash,
+					status: "pending",
+					createdAt: Date.now(),
+				});
+			} catch (err) {
+				setSuccessModal({
+					title: "Transaction failed",
+					message: err instanceof Error ? err.message : "Failed to create share class.",
+					variant: "error",
+				});
+			}
+		},
+		[capTableAddress, issuerId, directStockClass, setSuccessModal],
+	);
+
+	const handleStakeholder = useCallback(
+		async (data: StakeholderData) => {
+			if (!requireWriteReady()) return;
+			try {
+				const stakeholderBytes16 = generateBytes16Id() as `0x${string}`;
+				const stakeholderUuid = bytes16ToUuid(stakeholderBytes16);
+				const result = await directStakeholder.createStakeholder({
+					capTableAddress: capTableAddress as `0x${string}`,
+					stakeholderType: data.stakeholder_type,
+					currentRelationship: data.current_relationship,
+					id: stakeholderBytes16,
+				});
+				const activityId = `sh-${stakeholderUuid}-${Date.now()}`;
+				const legalName = data.name?.legal_name || "Shareholder";
+				setPendingActivityId(activityId);
+				setPendingStakeholder(true);
+				setPendingStakeholderMeta({ id: stakeholderUuid, data });
+				setDirectStakeholders((prev) => [
+					...prev,
+					{
+						_id: stakeholderUuid,
+						name: data.name,
+						stakeholder_type: data.stakeholder_type,
+						current_relationship: data.current_relationship,
+					},
+				]);
+				pushActivity({
+					id: activityId,
+					issuerId,
+					kind: "stakeholder",
+					type: "Shareholder created",
+					details: legalName,
+					date: new Date().toISOString().slice(0, 10),
+					txHash: result.hash,
+					status: "pending",
+					createdAt: Date.now(),
+				});
+			} catch (err) {
+				setSuccessModal({
+					title: "Transaction failed",
+					message: err instanceof Error ? err.message : "Failed to add shareholder.",
+					variant: "error",
+				});
+			}
+		},
+		[capTableAddress, issuerId, directStakeholder, setSuccessModal],
+	);
+
+	const handleIssuance = useCallback(
+		async (data: StockIssuanceData) => {
+			if (!requireWriteReady()) return;
+
+			const issuer = holdings?.issuer;
+			const stockClass =
+				directStockClasses.find((sc) => sc._id === data.stock_class_id) ||
+				(holdings?.stockClasses || []).find((sc: any) => sc._id === data.stock_class_id);
+			const people = [
+				...directStakeholders,
+				...(holdings?.stakeholders || []),
+				...(holdings?.holdings || []).map((h: { stakeholder?: any }) => h.stakeholder),
+			].filter(Boolean);
+			const stakeholder = people.find((sh: any) => sh._id === data.stakeholder_id);
+
+			const cap = validateShareCaps({
+				quantity: data.quantity,
+				issuerAuthorized: issuer?.initial_shares_authorized ?? 0,
+				issuerIssued: (holdings?.holdings || []).reduce(
+					(sum: number, h: any) => sum + (Number(h.quantity) || 0),
+					0,
+				),
+				classAuthorized: stockClass?.initial_shares_authorized ?? stockClass?.shares_authorized,
+				classIssued: (holdings?.holdings || [])
+					.filter((h: any) => h.stockClass?._id === data.stock_class_id)
+					.reduce((sum: number, h: any) => sum + (Number(h.quantity) || 0), 0),
+			});
+
+			if (!cap.ok) {
+				setSuccessModal({ title: "Not enough shares", message: cap.errors.join(" ") });
+				return;
+			}
+
+			try {
+				const sessionClass = directStockClasses.find((d) => d._id === data.stock_class_id);
+				const onchainOk =
+					sessionClass?.onchain === true ||
+					stockClass?.is_onchain_synced === true ||
+					(stockClass?.is_onchain_synced !== false && !sessionClass && !!stockClass);
+				if (!onchainOk || stockClass?.is_onchain_synced === false) {
+					if (!sessionClass?.onchain) {
+						setSuccessModal({
+							title: "Stock class isn’t ready yet",
+							message:
+								"Go to Stock classes, create the class, and confirm in your wallet. Then come back to Issue stock.",
+							variant: "info",
+						});
+						return;
+					}
+				}
+
+				const result = await directIssuance.issueStock({
+					capTableAddress: capTableAddress as `0x${string}`,
+					stakeholderId: data.stakeholder_id,
+					stockClassId: data.stock_class_id,
+					quantity: data.quantity,
+					sharePriceAmount: data.share_price?.amount || "0",
+					customId: data.custom_id,
+					comments: data.comments,
+				});
+
+				const activityId = `iss-${result.issuanceId}-${Date.now()}`;
+				const holderName =
+					stakeholder?.name?.legal_name || stakeholder?.name?.first_name || "Holder";
+				const className = stockClass?.name || "Class";
+				setPendingActivityId(activityId);
+				setPendingIssuance(true);
+				setDirectIssuances((prev) => [
+					...prev,
+					{
+						_id: result.issuanceId,
+						security_id: result.securityId,
+						quantity: data.quantity,
+						stakeholder_id: data.stakeholder_id,
+						stock_class_id: data.stock_class_id,
+						share_price: data.share_price,
+						stakeholder_name: holderName,
+						stock_class_name: className,
+						custom_id: data.custom_id,
+						txHash: result.hash,
+						date: new Date().toISOString().slice(0, 10),
+					},
+				]);
+				pushActivity({
+					id: activityId,
+					issuerId,
+					kind: "stock_issuance",
+					type: "Stock issued",
+					details: data.custom_id || `${holderName} · ${className}`,
+					quantity: data.quantity,
+					price: data.share_price?.amount
+						? `${data.share_price.amount} ${data.share_price.currency || "USD"}`
+						: undefined,
+					date: new Date().toISOString().slice(0, 10),
+					txHash: result.hash,
+					status: "pending",
+					createdAt: Date.now(),
+				});
+
+				registerStockIssuanceOnchain({ issuerId, data }).catch((err) =>
+					console.warn("Failed to register stock issuance metadata:", err),
+				);
+				refreshHoldings();
+			} catch (err) {
+				setSuccessModal({
+					title: "Transaction failed",
+					message: err instanceof Error ? err.message : "Failed to issue stock.",
+					variant: "error",
+				});
+			}
+		},
+		[
+			capTableAddress,
+			issuerId,
+			holdings,
+			directStockClasses,
+			directStakeholders,
+			directIssuance,
+			refreshHoldings,
+			setSuccessModal,
+		],
+	);
+
+	const handleTransfer = useCallback(
+		async (data: TransferStockFormData) => {
+			if (!requireWriteReady()) return;
+
+			const people = [
+				...directStakeholders,
+				...(holdings?.stakeholders || []),
+				...(holdings?.holdings || []).map((h: { stakeholder?: any }) => h.stakeholder),
+			].filter(Boolean);
+			const from = people.find((s: any) => s._id === data.transferor_id);
+			const to = people.find((s: any) => s._id === data.transferee_id);
+			const sc =
+				directStockClasses.find((c) => c._id === data.stock_class_id) ||
+				(holdings?.stockClasses || []).find((c: any) => c._id === data.stock_class_id);
+
+			const held = (holdings?.holdings || [])
+				.filter(
+					(h: any) =>
+						h.stakeholder?._id === data.transferor_id &&
+						h.stockClass?._id === data.stock_class_id,
+				)
+				.reduce((sum: number, h: any) => sum + (Number(h.quantity) || 0), 0);
+
+			const qty = Number(data.quantity);
+			if (!Number.isFinite(qty) || qty <= 0) {
+				setSuccessModal({
+					title: "Invalid quantity",
+					message: "Enter a positive number of shares to transfer.",
+					variant: "info",
+				});
+				return;
+			}
+			if (qty > held) {
+				setSuccessModal({
+					title: "Not enough shares",
+					message: `${from?.name?.legal_name || "Transferor"} only holds ${held.toLocaleString()} of this class.`,
+					variant: "info",
+				});
+				return;
+			}
+
+			try {
+				const result = await directTransfer.transferStock({
+					capTableAddress: capTableAddress as `0x${string}`,
+					transferorId: data.transferor_id,
+					transfereeId: data.transferee_id,
+					stockClassId: data.stock_class_id,
+					quantity: data.quantity,
+					sharePriceAmount: data.share_price?.amount || "0",
+				});
+
+				const fromName = from?.name?.legal_name || "From";
+				const toName = to?.name?.legal_name || "To";
+				const className = sc?.name || "Class";
+				const activityId = `xfer-${data.transferor_id.slice(0, 8)}-${Date.now()}`;
+				setPendingActivityId(activityId);
+				setPendingTransfer(true);
+				pushActivity({
+					id: activityId,
+					issuerId,
+					kind: "stock_transfer",
+					type: "Stock transferred",
+					details: `${fromName} → ${toName} · ${className}`,
+					quantity: data.quantity,
+					price: data.share_price?.amount
+						? `${data.share_price.amount} ${data.share_price.currency || "USD"}`
+						: undefined,
+					date: new Date().toISOString().slice(0, 10),
+					txHash: result.hash,
+					status: "pending",
+					createdAt: Date.now(),
+				});
+				refreshHoldings();
+			} catch (err) {
+				setSuccessModal({
+					title: "Transaction failed",
+					message: err instanceof Error ? err.message : "Failed to transfer stock.",
+					variant: "error",
+				});
+			}
+		},
+		[
+			capTableAddress,
+			issuerId,
+			holdings,
+			directStockClasses,
+			directStakeholders,
+			directTransfer,
+			refreshHoldings,
+			setSuccessModal,
+		],
+	);
+
+	return {
+		handleStockClass,
+		handleStakeholder,
+		handleIssuance,
+		handleTransfer,
+		directStockClasses,
+		directStakeholders,
+		directIssuances,
+		pendingStockClass,
+		pendingStakeholder,
+		pendingIssuance,
+		pendingTransfer,
+	};
+}

--- a/app/src/components/cap-table/useWalletReceipt.ts
+++ b/app/src/components/cap-table/useWalletReceipt.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from "react";
+import {
+	markActivityByTx,
+	updateActivity,
+	type ActivityEntry,
+} from "../../utils/activityLog";
+import type { SuccessModalState } from "./types";
+
+export interface WalletReceiptAction {
+	isConfirmed: boolean;
+	isReverted: boolean;
+	hash: string | undefined;
+	errorMessage: string | null;
+	reset: () => void;
+}
+
+interface UseWalletReceiptArgs {
+	pending: boolean;
+	action: WalletReceiptAction;
+	issuerId: string;
+	pendingActivityId: string | null;
+	setPendingActivityId: (id: string | null) => void;
+	setActivityLog: (log: ActivityEntry[]) => void;
+	setSuccessModal: (state: SuccessModalState | null) => void;
+	clearPending: () => void;
+	refreshHoldings: () => void;
+	/** Extra holdings polls after confirm (issuance / transfer). */
+	delayedRefresh?: boolean;
+	confirmed: { title: string; variant?: SuccessModalState["variant"] };
+	reverted: { title: string; message: string; variant?: SuccessModalState["variant"] };
+	onConfirmed?: (hash: string | undefined) => void;
+	onReverted?: () => void;
+}
+
+/**
+ * Shared wallet-receipt lifecycle: pending → confirmed | reverted.
+ * Callbacks live on a ref so identity changes do not retrigger the effect.
+ */
+export function useWalletReceipt(args: UseWalletReceiptArgs) {
+	const argsRef = useRef(args);
+	argsRef.current = args;
+
+	const delayTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+	useEffect(() => {
+		return () => {
+			delayTimers.current.forEach(clearTimeout);
+			delayTimers.current = [];
+		};
+	}, []);
+
+	const { pending, isConfirmed, isReverted, hash } = {
+		pending: args.pending,
+		isConfirmed: args.action.isConfirmed,
+		isReverted: args.action.isReverted,
+		hash: args.action.hash,
+	};
+
+	useEffect(() => {
+		const o = argsRef.current;
+		if (!o.pending) return;
+
+		if (o.action.isConfirmed) {
+			const txHash = o.action.hash;
+			o.setSuccessModal({
+				title: o.confirmed.title,
+				txHash,
+				variant: o.confirmed.variant,
+			});
+			o.onConfirmed?.(txHash);
+			if (o.pendingActivityId && o.issuerId) {
+				o.setActivityLog(
+					updateActivity(o.issuerId, o.pendingActivityId, {
+						status: "confirmed",
+						txHash: txHash || undefined,
+					}),
+				);
+			} else if (txHash && o.issuerId) {
+				o.setActivityLog(markActivityByTx(o.issuerId, txHash, "confirmed"));
+			}
+			o.setPendingActivityId(null);
+			o.clearPending();
+			o.action.reset();
+			o.refreshHoldings();
+			if (o.delayedRefresh) {
+				delayTimers.current.forEach(clearTimeout);
+				delayTimers.current = [
+					setTimeout(() => o.refreshHoldings(), 1500),
+					setTimeout(() => o.refreshHoldings(), 4000),
+				];
+			}
+		} else if (o.action.isReverted) {
+			o.setSuccessModal({
+				title: o.reverted.title,
+				message: o.action.errorMessage || o.reverted.message,
+				variant: o.reverted.variant,
+			});
+			if (o.pendingActivityId && o.issuerId) {
+				o.setActivityLog(
+					updateActivity(o.issuerId, o.pendingActivityId, { status: "reverted" }),
+				);
+			}
+			o.onReverted?.();
+			o.setPendingActivityId(null);
+			o.clearPending();
+			o.action.reset();
+		}
+	}, [pending, isConfirmed, isReverted, hash]);
+}


### PR DESCRIPTION
## What
Company workspace left nav is now the component map. `CapTableDashboard` is a shell that imports:

- `Holdings`
- `StockClasses`
- `Shareholders`
- `IssueStock`
- `Transfer`
- `Transactions`

Wallet receipt lifecycle lives in `useWalletReceipt`; class / person / issue / transfer submits live in `useCapTableWrites`.

## Why
The 977-line orchestrator was the next-feature bottleneck (`acceptStock` and anything else). Screens should match the COMPANY section names, not a `views/*View` pile.

## How
- Lifted the six screens out of `views/` (drop `*View` suffix)
- Extracted the four copy-paste receipt effects and the four wallet handlers
- Kept Playwright `data-testid` values (`view-overview`, `view-stock-classes`, …)
- No product behavior change; `SAMPLE_ISSUER` and landing addresses untouched

## Verify
- `pnpm --filter tap-app typecheck`
- `pnpm --filter tap-app test:nav` (32/32)
- `pnpm --filter tap-app lint`
- `pnpm --filter tap-app test:e2e` — 61 passed, 5 skipped (viewport-only, pre-existing)

Host `:3000` is the Docker `next start` app, not this branch. E2E built from this source on `:3100` and clicked Holdings → Stock classes → Shareholders → Issue stock → Transfer → Transactions.

## Out of scope
Beacon upgrade, zip import, wagmi hook trim, `/create` routes, `acceptStock` UI.